### PR TITLE
Remove responsive websites from scopes

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -3,6 +3,8 @@
     "es2015", "react"
   ],
   "plugins": [
-    "transform-object-rest-spread"
+    "transform-object-rest-spread",
+    "transform-es2015-arrow-functions",
+    "transform-class-properties"
   ]
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -5,11 +5,8 @@
     "es6": true
   },
   "extends": "eslint:recommended",
+  "parser": "babel-eslint",
   "parserOptions": {
-    "ecmaFeatures": {
-      "experimentalObjectRestSpread": true,
-      "jsx": true
-    },
     "sourceType": "module"
   },
   "plugins": [

--- a/package.json
+++ b/package.json
@@ -35,6 +35,8 @@
   "dependencies": {
     "@storybook/react": "^3.0.0",
     "cross-env": "^5.0.1",
+    "glamor": "^2.20.40",
+    "glamorous": "^4.11.0",
     "jspdf": "^1.3.3",
     "path": "^0.12.7",
     "react": "^16.0.0",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
     "aphrodite": "^1.2.1",
     "babel-core": "^6.24.1",
     "babel-loader": "^7.0.0",
+    "babel-plugin-transform-class-properties": "^6.24.1",
+    "babel-plugin-transform-es2015-arrow-functions": "^6.22.0",
     "babel-plugin-transform-object-rest-spread": "^6.23.0",
     "babel-preset-es2015": "^6.24.1",
     "babel-preset-react": "^6.24.1",
@@ -34,6 +36,7 @@
   },
   "dependencies": {
     "@storybook/react": "^3.0.0",
+    "babel-eslint": "^8.0.3",
     "cross-env": "^5.0.1",
     "glamor": "^2.20.40",
     "glamorous": "^4.11.0",

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -1,10 +1,6 @@
 // Action types
-export const NEXT_SETUP_STEP = 'NEXT_SETUP_STEP'
-export const SET_SCOPE = 'SET_SCOPE'
 export const SET_SCOPES = 'SET_SCOPES'
-export const SET_SETUP_TO_FINISHED = 'SET_SETUP_TO_FINISHED'
-export const PREVIOUS_SETUP_STEP = 'PREVIOUS_SETUP_STEP'
-export const RESET_SETUP = 'RESET_SETUP'
+export const RESET_SCOPES = 'RESET_SCOPES'
 export const SET_VALUE_FOR_KEY = 'SET_VALUE_FOR_KEY'
 export const SET_GENERAL_VALUE_FOR_KEY = 'SET_GENERAL_VALUE_FOR_KEY'
 export const SET_VALUE_IN_AREA = 'SET_VALUE_IN_AREA'
@@ -17,43 +13,12 @@ export const SET_BASE_COLORS = 'SET_BASE_COLORS'
 export const SET_COLOR_CONTRAST = 'SET_COLOR_CONTRAST'
 export const RESET_TYPOGRAPHY_DATA = 'RESET_TYPOGRAPHY_DATA'
 
-export const nextSetupStep = () => {
-  return {
-    type: NEXT_SETUP_STEP
-  }
-}
+export const setScopes = scopes => ({
+  type: SET_SCOPES,
+  scopes
+})
 
-export const setScope = scope => {
-  return {
-    type: SET_SCOPE,
-    scope
-  }
-}
-
-export const setScopes = scopes => {
-  return {
-    type: SET_SCOPES,
-    scopes
-  }
-}
-
-export const setSetupToFinished = () => {
-  return {
-    type: SET_SETUP_TO_FINISHED
-  }
-}
-
-export const previousSetupStep = () => {
-  return {
-    type: PREVIOUS_SETUP_STEP
-  }
-}
-
-export const resetSetup = () => {
-  return {
-    type: RESET_SETUP
-  }
-}
+export const resetScopes = () => ({ type: RESET_SCOPES })
 
 export const setValueForKey = (key, value) => {
   return {

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -1,6 +1,7 @@
 // Action types
 export const NEXT_SETUP_STEP = 'NEXT_SETUP_STEP'
 export const SET_SCOPE = 'SET_SCOPE'
+export const SET_SCOPES = 'SET_SCOPES'
 export const SET_SETUP_TO_FINISHED = 'SET_SETUP_TO_FINISHED'
 export const PREVIOUS_SETUP_STEP = 'PREVIOUS_SETUP_STEP'
 export const RESET_SETUP = 'RESET_SETUP'
@@ -26,6 +27,13 @@ export const setScope = scope => {
   return {
     type: SET_SCOPE,
     scope
+  }
+}
+
+export const setScopes = scopes => {
+  return {
+    type: SET_SCOPES,
+    scopes
   }
 }
 

--- a/src/components/colors/Colors.jsx
+++ b/src/components/colors/Colors.jsx
@@ -16,6 +16,10 @@ class Colors extends React.Component {
   constructor(props) {
     super(props)
 
+    this.scope = this.props.scopes[1]
+      ? this.props.scopes[1].value
+      : null
+
     this.handleColorPickerChange = this.handleColorPickerChange.bind(this)
     this.handleBaseColorPickerChange = this.handleBaseColorPickerChange.bind(this)
     this.handleAccentColorSelectorClick = this.handleAccentColorSelectorClick.bind(this)
@@ -67,7 +71,7 @@ class Colors extends React.Component {
   }
 
   determineNextStep(baseColors) {
-    if (this.props.scopes[1] === SCOPES.IOS) {
+    if (this.scope === SCOPES.IOS) {
       this.props.finishColorWizard()
       this.props.setBaseColors(baseColors)
     } else {
@@ -77,7 +81,7 @@ class Colors extends React.Component {
   }
 
   determinePreviousStep() {
-    if (this.props.scopes[1] === SCOPES.IOS) {
+    if (this.scope === SCOPES.IOS) {
       this.props.firstColorWizardStep()
     } else {
       this.props.previousSetupStep()
@@ -90,7 +94,7 @@ class Colors extends React.Component {
       case 1:
         return (
           <BaseColorController
-            scope={this.props.scopes[1]}
+            scope={this.scope}
             colorSet={this.props.colorSet}
             colors={this.props.baseColors}
             dropdownChange={this.handleDropdownChange}
@@ -100,7 +104,7 @@ class Colors extends React.Component {
           />
         )
       case 2:
-        if (this.props.scopes[1] === SCOPES.ANDROID) {
+        if (this.scope === SCOPES.ANDROID) {
           return (
             <AndroidAccentColorController
               baseColors={this.props.baseColors}

--- a/src/components/setup/ButtonNavigation.jsx
+++ b/src/components/setup/ButtonNavigation.jsx
@@ -1,0 +1,43 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import glamorous from 'glamorous'
+
+import SecondaryButton from '../shared/SecondaryButton.jsx'
+
+const Wrapper = glamorous.div({
+  display: 'flex',
+  justifyContent: 'space-between'
+}, props => {
+  if (props.singleItem) {
+    return {
+      justifyContent: 'flex-end'
+    }
+  }
+})
+
+const ButtonNavigation = ({ nextButtonAction, nextActionForbidden, previousButtonAction }) => (
+  <Wrapper singleItem={!previousButtonAction}>
+    {
+      previousButtonAction &&
+      <SecondaryButton
+        onClick={previousButtonAction}
+        variant='outline'
+      >
+        Back
+      </SecondaryButton>
+    }
+    <SecondaryButton
+      onClick={nextButtonAction}
+      inactive={nextActionForbidden}
+    >
+      Next
+    </SecondaryButton>
+  </Wrapper>
+)
+
+ButtonNavigation.propTypes = {
+  nextButtonAction: PropTypes.func,
+  previousButtonAction: PropTypes.func
+}
+
+export default ButtonNavigation

--- a/src/components/setup/IconButton.jsx
+++ b/src/components/setup/IconButton.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import glamorous from 'glamorous'
 
 import {baseColors, appColors} from '../../styles/base/colors.js'
@@ -26,9 +27,9 @@ const Button = glamorous.button({
   }
 })
 
-const IconButton = ({ onClick, isActive, children, identifier, icon }) => (
+const IconButton = ({ onClick, isActive, children, value, icon }) => (
   <Button
-    onClick={() => onClick(identifier)}
+    onClick={() => onClick(value)}
     isActive={isActive}
   >
     <SpacingInset size='l'>
@@ -38,5 +39,17 @@ const IconButton = ({ onClick, isActive, children, identifier, icon }) => (
     </SpacingInset>
   </Button>
 )
+
+IconButton.propTypes = {
+  onClick: PropTypes.func.isRequired,
+  isActive: PropTypes.bool,
+  children: PropTypes.node.isRequired,
+  value: PropTypes.string.isRequired,
+  icon: PropTypes.string.isRequired
+}
+
+IconButton.defaultProps = {
+  isActive: false
+}
 
 export default IconButton

--- a/src/components/setup/IconButton.jsx
+++ b/src/components/setup/IconButton.jsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { StyleSheet, css } from 'aphrodite'
+import glamorous from 'glamorous'
 
 import {baseColors, appColors} from '../../styles/base/colors.js'
 import {fontSizes} from '../../styles/base/fonts.js'
@@ -7,70 +7,36 @@ import SpacingInset from '../helpers/spacing/SpacingInset.jsx'
 import SpacingStack from '../helpers/spacing/SpacingStack.jsx'
 import Icon from '../shared/Icon.jsx'
 
-class IconButton extends React.Component {
-  constructor(props) {
-    super(props)
-    this.toggleHoverState = this.toggleHoverState.bind(this)
-    this.state ={
-      hover: false
-    }
-  }
-
-  toggleHoverState() {
-    this.setState({
-      hover: !this.state.hover
-    })
-  }
-
-  computeIconColor() {
-    return this.state.hover || this.props.active ? appColors.secondary : baseColors.lighterMidGrey
-  }
-
-  render() {
-    return (
-      <button
-        onMouseOver={this.toggleHoverState}
-        onMouseOut={this.toggleHoverState}
-        onClick={() => this.props.onClick(this.props.identifier)}
-        className={css(
-          styles.baseStyles,
-          this.state.hover && styles.hoverStyles,
-          this.props.active && styles.activeStyles
-        )}
-      >
-        <SpacingInset size='l'>
-          <Icon icon={this.props.icon} color={this.computeIconColor()} size='40' />
-          <SpacingStack size='l' />
-          {this.props.children}
-        </SpacingInset>
-      </button>
-    )
-  }
-}
-
-const styles = StyleSheet.create({
-  baseStyles: {
-    width: '100%',
-    backgroundColor: baseColors.white,
-    borderRadius: '4px',
-    borderStyle: 'solid',
-    borderWidth: '2px',
-    borderColor: baseColors.lighterMidGrey,
-    color: baseColors.lighterMidGrey,
-    fontSize: fontSizes.m,
-    cursor: 'pointer',
-    ':focus': {
-      outline: 0
-    }
-  },
-  hoverStyles: {
+const Button = glamorous.button({
+  backgroundColor: baseColors.white,
+  borderRadius: '4px',
+  border: `2px solid ${baseColors.lighterMidGrey}`,
+  color: baseColors.lighterMidGrey,
+  fontSize: fontSizes.m,
+  ':hover': {
     borderColor: appColors.secondary,
     color: appColors.secondary
-  },
-  activeStyles: {
-    borderColor: appColors.secondary,
-    color: appColors.secondary
+  }
+}, props => {
+  if (props.isActive) {
+    return {
+      borderColor: appColors.secondary,
+      color: appColors.secondary
+    }
   }
 })
+
+const IconButton = ({ onClick, isActive, children, identifier, icon }) => (
+  <Button
+    onClick={() => onClick(identifier)}
+    isActive={isActive}
+  >
+    <SpacingInset size='l'>
+      <Icon icon={icon} size='40' />
+      <SpacingStack size='l' />
+      {children}
+    </SpacingInset>
+  </Button>
+)
 
 export default IconButton

--- a/src/components/setup/IconButton.jsx
+++ b/src/components/setup/IconButton.jsx
@@ -17,6 +17,9 @@ const Button = glamorous.button({
   ':hover': {
     borderColor: appColors.secondary,
     color: appColors.secondary
+  },
+  ':focus': {
+    outline: 0
   }
 }, props => {
   if (props.isActive) {

--- a/src/components/setup/IconButton.jsx
+++ b/src/components/setup/IconButton.jsx
@@ -9,6 +9,7 @@ import SpacingStack from '../helpers/spacing/SpacingStack.jsx'
 import Icon from '../shared/Icon.jsx'
 
 const Button = glamorous.button({
+  width: '100%',
   backgroundColor: baseColors.white,
   borderRadius: '4px',
   border: `2px solid ${baseColors.lighterMidGrey}`,

--- a/src/components/setup/IconButton.jsx
+++ b/src/components/setup/IconButton.jsx
@@ -36,7 +36,7 @@ const IconButton = ({ onClick, isActive, children, value, icon }) => (
     isActive={isActive}
   >
     <SpacingInset size='l'>
-      <Icon icon={icon} size='40' />
+      <Icon icon={icon} size={40} />
       <SpacingStack size='l' />
       {children}
     </SpacingInset>

--- a/src/components/setup/IconButtonList.jsx
+++ b/src/components/setup/IconButtonList.jsx
@@ -1,0 +1,38 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import glamorous from 'glamorous'
+
+import IconButton from './IconButton'
+
+const Wrapper = glamorous.div({
+  display: 'flex',
+  justifyContent: 'space-between'
+})
+
+const Item = glamorous.div({
+  width: '30%'
+})
+
+const IconButtonList = ({ items, onItemClick, activeItem }) => (
+  <Wrapper>
+    {items.map(item => (
+      <Item>
+        <IconButton
+          onClick={onItemClick}
+          icon={item.icon}
+          isActive={item.value === activeItem}
+          value={item.value}
+        >
+          {item.name}
+        </IconButton>
+      </Item>
+    ))}
+  </Wrapper>
+)
+
+IconButtonList.propTypes = {
+  items: PropTypes.arrayOf(PropTypes.object).isRequired,
+  onItemClick: PropTypes.func.isRequired
+}
+
+export default IconButtonList

--- a/src/components/setup/IconButtonList.jsx
+++ b/src/components/setup/IconButtonList.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import glamorous from 'glamorous'
 
-import IconButton from './IconButton'
+import IconButton from './IconButton.jsx'
 
 const Wrapper = glamorous.div({
   display: 'flex',
@@ -32,7 +32,8 @@ const IconButtonList = ({ items, onItemClick, activeItem }) => (
 
 IconButtonList.propTypes = {
   items: PropTypes.arrayOf(PropTypes.object).isRequired,
-  onItemClick: PropTypes.func.isRequired
+  onItemClick: PropTypes.func.isRequired,
+  activeItem: PropTypes.string
 }
 
 export default IconButtonList

--- a/src/components/setup/IconButtonList.jsx
+++ b/src/components/setup/IconButtonList.jsx
@@ -16,7 +16,7 @@ const Item = glamorous.div({
 const IconButtonList = ({ items, onItemClick, activeItem }) => (
   <Wrapper>
     {items.map(item => (
-      <Item>
+      <Item key={item.value}>
         <IconButton
           onClick={onItemClick}
           icon={item.icon}

--- a/src/components/setup/Setup.jsx
+++ b/src/components/setup/Setup.jsx
@@ -33,6 +33,7 @@ export default class App extends React.Component {
           setupSteps={'2'}
           setupOptions={setupOptions}
           setScope={this.props.setScope}
+          setScopes={this.props.setScopes}
           setSetupToFinished={this.props.setSetupToFinished}
           previousSetupStep={this.props.previousSetupStep}
         />

--- a/src/components/setup/Setup.jsx
+++ b/src/components/setup/Setup.jsx
@@ -3,8 +3,9 @@ import React from 'react'
 import Progress from '../shared/Progress.jsx'
 import IntroductionHero from './IntroductionHero.jsx'
 import SpacingStack from '../helpers/spacing/SpacingStack.jsx'
-import SetupProgress from './SetupProgress.jsx'
+import SetupWizard from './SetupWizard.jsx'
 import SetupSummary from './SetupSummary.jsx'
+import BorderedBox from '../shared/BorderedBox.jsx'
 import BottomNavigation from '../shared/BottomNavigation.jsx'
 
 import {setupOptions} from '../../helpers/constants/setupOptions.js'
@@ -17,28 +18,20 @@ export default class App extends React.Component {
   }
 
   renderSetupStep() {
-    if (this.props.setupFinished) {
+    if (this.props.scopesSelected) {
       return (
         <SetupSummary
-          setupOptions={setupOptions}
           scopes={this.props.scopes}
           resetSetup={this.props.resetSetup}
         />
       )
-    } else {
-      return (
-        <SetupProgress
-          scopes={this.props.scopes}
-          setupStep={this.props.setupStep}
-          setupSteps={'2'}
-          setupOptions={setupOptions}
-          setScope={this.props.setScope}
-          setScopes={this.props.setScopes}
-          setSetupToFinished={this.props.setSetupToFinished}
-          previousSetupStep={this.props.previousSetupStep}
-        />
-      )
     }
+    return (
+      <SetupWizard
+        setupOptions={setupOptions}
+        setScopes={this.props.setScopes}
+      />
+    )
   }
 
   render() {
@@ -47,9 +40,11 @@ export default class App extends React.Component {
         <Progress currentPath={this.props.location.pathname} />
         <SpacingStack size='l' />
         <IntroductionHero />
-        {this.renderSetupStep()}
+        <BorderedBox>
+          {this.renderSetupStep()}
+        </BorderedBox>
         <SpacingStack size='xxl' />
-        <BottomNavigation to='/typography' inactive={!this.props.setupFinished} title='Next Section' />
+        <BottomNavigation to='/typography' inactive={!this.props.scopesSelected} title='Next Section' />
       </div>
     )
   }

--- a/src/components/setup/SetupProgress.jsx
+++ b/src/components/setup/SetupProgress.jsx
@@ -1,146 +1,87 @@
 import React from 'react'
-import {StyleSheet, css} from 'aphrodite'
 
 import SpacingInset from '../helpers/spacing/SpacingInset.jsx'
-import IconButton from './IconButton.jsx'
-import SecondaryButton from '../shared/SecondaryButton.jsx'
 import BorderedBox from '../shared/BorderedBox.jsx'
+import IconButtonList from './IconButtonList.jsx'
+import ButtonNavigation from './ButtonNavigation.jsx'
 
 class SetupProgress extends React.Component {
   constructor(props) {
     super(props)
-    this.handleIconButtonClick = this.handleIconButtonClick.bind(this)
-    this.handleButtonClick = this.handleButtonClick.bind(this)
-    this.handleBackButtonClick = this.handleBackButtonClick.bind(this)
-    this.constructIconButtons = this.constructIconButtons.bind(this)
-    this.generateContent = this.generateContent.bind(this)
 
     this.state = {
-      activeOption: false
+      activeOption: {},
+      selectedScopes: [],
+      currentOptions: Object.values(props.setupOptions)
     }
   }
 
-  handleIconButtonClick(key) {
+  handleBackButtonClick = () => {
+    const { selectedScopes } = this.state
+    selectedScopes.pop()
+
     this.setState({
-      activeOption: key
+      selectedScopes: selectedScopes,
+      currentOptions: Object.values(this.props.setupOptions),
+      activeOption: {}
     })
   }
 
-  handleButtonClick() {
-    this.props.setScope(this.state.activeOption)
+  handleNextButtonClick = () => {
+    const { activeOption } = this.state
+    if (!activeOption) return
 
-    // If the current setup step is the last, also set the setup state to finished
-    if (this.props.setupStep == this.props.setupSteps) {
-      this.props.setSetupToFinished()
+    const reducedOption = {
+      name: activeOption.name,
+      value: activeOption.value,
+      icon: activeOption.icon
     }
 
-    // Reset this components' internal state to disable the button
+    if (!activeOption.subsequent_options) {
+      return this.props.setScopes([...this.state.selectedScopes, reducedOption])
+    }
+
+    this.setState(({ selectedScopes }) => ({
+      selectedScopes: [...selectedScopes, reducedOption],
+      currentOptions: activeOption.subsequent_options,
+      activeOption: {}
+    }))
+  }
+
+  handleItemClick = value => {
+    const { currentOptions } = this.state
+    const mactchingOption = currentOptions.find(option => (
+      option.value === value
+    ))
+
     this.setState({
-      activeOption: false
+      activeOption: mactchingOption
     })
-  }
-
-  handleBackButtonClick() {
-    this.props.previousSetupStep()
-  }
-
-  /**
-   * Generates the main content for the setup component (i.e. Iconbuttons).
-   * Determines the correct subset of options and calls constructIconButtons()
-   * with that supset.
-   *
-   * @return {Array} An array of IconButtons ready for rendering
-   */
-  generateContent() {
-    let setupOptions = []
-
-    /**
-     * If this is the first step in the setup, only use options
-     * marked as initial options.
-     * Else, got through all options and determine for every one,
-     * if it should be displayed
-     */
-    if (this.props.setupStep == 1) {
-      for (var i = 0; i < this.props.setupOptions.length; i++) {
-        let currentOption = this.props.setupOptions[i]
-
-        if (currentOption.initialOption)
-          setupOptions.push(currentOption)
-      }
-    } else {
-      for (var j = 0; j < this.props.setupOptions.length; j++) {
-        let currentOption = this.props.setupOptions[j]
-
-        // An element should only be displayed, if its scope matches on of the global scopes
-        if (this.props.scopes.indexOf(currentOption.shouldDisplayForScope) > -1)
-          setupOptions.push(currentOption)
-      }
-    }
-
-    return this.constructIconButtons(setupOptions)
-  }
-
-  /**
-   * Constrocts an array of IconButtons based on a given set of options
-   *
-   * NOTE: This will construct an IconButton for every element in the given options
-   * and does not validate them.
-   *
-   * @param {Array} setupOptions
-   * @returns {Array} An Array of iconButtons
-   */
-  constructIconButtons(setupOptions) {
-    let iconButtons = []
-    for (var i = 0; i < setupOptions.length; i++) {
-      let currentOption = setupOptions[i]
-
-      iconButtons.push(
-        <div className={css(styles.iconButtonWrapper)}>
-          <IconButton
-            icon={currentOption.icon}
-            onClick={this.handleIconButtonClick}
-            key={i}
-            identifier={currentOption.value}
-            active={this.state.activeOption === currentOption.value}
-          >
-            {currentOption.text}
-          </IconButton>
-        </div>
-
-      )
-    }
-
-    return iconButtons
   }
 
   render() {
+    const { selectedScopes } = this.state
+
     return (
       <BorderedBox>
         <SpacingInset size='l'>
           <span>Choose what you are building</span>
           <SpacingInset size='l' />
-          <div className={css(styles.buttonWrapperStyles)}>
-            {this.generateContent()}
-          </div>
+          <IconButtonList
+            items={this.state.currentOptions}
+            activeItem={this.state.activeOption.value}
+            onItemClick={this.handleItemClick}
+          />
           <SpacingInset size='l' />
-          <div className={css(styles.buttonWrapperStyles)}>
-            <SecondaryButton inactive={this.props.setupStep < 2} onClick={this.handleBackButtonClick} variant={'outline'}>Back</SecondaryButton>
-            <SecondaryButton inactive={this.state.activeOption == false} onClick={this.handleButtonClick}>Next Step</SecondaryButton>
-          </div>
+          <ButtonNavigation
+            nextButtonAction={this.handleNextButtonClick}
+            nextActionForbidden={!this.state.activeOption}
+            previousButtonAction={selectedScopes.length > 0 ? this.handleBackButtonClick : null}
+          />
         </SpacingInset>
       </BorderedBox>
     )
   }
 }
-
-const styles = StyleSheet.create({
-  buttonWrapperStyles: {
-    display: 'flex',
-    justifyContent: 'space-between'
-  },
-  iconButtonWrapper: {
-    width: '30%'
-  }
-})
 
 export default SetupProgress

--- a/src/components/setup/SetupSummary.jsx
+++ b/src/components/setup/SetupSummary.jsx
@@ -8,14 +8,12 @@ import SpacingStack from '../helpers/spacing/SpacingStack.jsx'
 import SpacingInline from '../helpers/spacing/SpacingInline.jsx'
 import SecondaryButton from '../shared/SecondaryButton.jsx'
 import Icon from '../shared/Icon.jsx'
-import { extractScopeInformation } from '../../helpers/functions/scopes.js'
 
 function buildSummary(scopes) {
-  let extractedScopes = extractScopeInformation(scopes)
   let summaryElemets = []
 
-  for (var i = 0; i < extractedScopes.length; i++) {
-    let currentScope = extractedScopes[i]
+  for (var i = 0; i < scopes.length; i++) {
+    let currentScope = scopes[i]
     summaryElemets.push(
       <SpacingStack size='l' key={i} >
         <div className={css(styles.SummaryItemStyles)}>
@@ -25,7 +23,7 @@ function buildSummary(scopes) {
           <SpacingInline size={'l'} >
             <Icon icon={currentScope.icon} color={appColors.secondary} size={42} />
           </SpacingInline>
-          <span>{currentScope.text}</span>
+          <span>{currentScope.name}</span>
         </div>
       </SpacingStack>
     )

--- a/src/components/setup/SetupSummary.jsx
+++ b/src/components/setup/SetupSummary.jsx
@@ -2,8 +2,6 @@ import React from 'react'
 import {StyleSheet, css} from 'aphrodite'
 
 import {appColors} from '../../styles/base/colors.js'
-import BorderedBox from '../shared/BorderedBox.jsx'
-import SpacingInset from '../helpers/spacing/SpacingInset.jsx'
 import SpacingStack from '../helpers/spacing/SpacingStack.jsx'
 import SpacingInline from '../helpers/spacing/SpacingInline.jsx'
 import SecondaryButton from '../shared/SecondaryButton.jsx'
@@ -34,18 +32,16 @@ function buildSummary(scopes) {
 
 function SetupSummary(props) {
   return (
-    <BorderedBox>
-      <SpacingInset size='l'>
-        <span>Great! Here is a summary of what your are going to build:</span>
-        <SpacingStack size={'xl'} />
-        {buildSummary(props.scopes)}
-        <SpacingStack size={'xl'} />
-        <span>If this is correct, you can use the red button on the bottom of the page to go to the next section.
+    <div>
+      <span>Great! Here is a summary of what your are going to build:</span>
+      <SpacingStack size={'xl'} />
+      {buildSummary(props.scopes)}
+      <SpacingStack size={'xl'} />
+      <span>If this is correct, you can use the red button on the bottom of the page to go to the next section.
 Otherwise, you can choose to start the setup again from the beginning.</span>
-        <SpacingStack size={'l'} />
-        <SecondaryButton variant={'outline'} onClick={props.resetSetup}>Start over</SecondaryButton>
-      </SpacingInset>
-    </BorderedBox>
+      <SpacingStack size={'l'} />
+      <SecondaryButton variant={'outline'} onClick={props.resetSetup}>Start over</SecondaryButton>
+    </div>
   )
 }
 

--- a/src/components/setup/SetupWizard.jsx
+++ b/src/components/setup/SetupWizard.jsx
@@ -1,11 +1,10 @@
 import React from 'react'
 
 import SpacingInset from '../helpers/spacing/SpacingInset.jsx'
-import BorderedBox from '../shared/BorderedBox.jsx'
 import IconButtonList from './IconButtonList.jsx'
 import ButtonNavigation from './ButtonNavigation.jsx'
 
-class SetupProgress extends React.Component {
+class SetupWizard extends React.Component {
   constructor(props) {
     super(props)
 
@@ -63,25 +62,23 @@ class SetupProgress extends React.Component {
     const { selectedScopes } = this.state
 
     return (
-      <BorderedBox>
-        <SpacingInset size='l'>
-          <span>Choose what you are building</span>
-          <SpacingInset size='l' />
-          <IconButtonList
-            items={this.state.currentOptions}
-            activeItem={this.state.activeOption.value}
-            onItemClick={this.handleItemClick}
-          />
-          <SpacingInset size='l' />
-          <ButtonNavigation
-            nextButtonAction={this.handleNextButtonClick}
-            nextActionForbidden={!this.state.activeOption}
-            previousButtonAction={selectedScopes.length > 0 ? this.handleBackButtonClick : null}
-          />
-        </SpacingInset>
-      </BorderedBox>
+      <div>
+        <span>Choose what you are building</span>
+        <SpacingInset size='l' />
+        <IconButtonList
+          items={this.state.currentOptions}
+          activeItem={this.state.activeOption.value}
+          onItemClick={this.handleItemClick}
+        />
+        <SpacingInset size='l' />
+        <ButtonNavigation
+          nextButtonAction={this.handleNextButtonClick}
+          nextActionForbidden={!this.state.activeOption}
+          previousButtonAction={selectedScopes.length > 0 ? this.handleBackButtonClick : null}
+        />
+      </div>
     )
   }
 }
 
-export default SetupProgress
+export default SetupWizard

--- a/src/components/shared/BorderedBox.jsx
+++ b/src/components/shared/BorderedBox.jsx
@@ -1,26 +1,29 @@
 import React from 'react'
-import {StyleSheet, css} from 'aphrodite'
+import PropTypes from 'prop-types'
+import glamorous from 'glamorous'
+import SpacingInset from '../helpers/spacing/SpacingInset.jsx'
 
 import {baseColors} from '../../styles/base/colors.js'
 
-function BorderedBox(props) {
+const Box = glamorous.div({
+  border: `1px solid ${baseColors.lighterMidGrey}`,
+  borderRadius: '4px',
+  maxWidth: '800px',
+  margin: '0 auto'
+})
+
+const BorderedBox = ({ children }) => {
   return (
-    <div className={css(styles.boxStyles)} >
-      {props.children}
-    </div>
+    <Box>
+      <SpacingInset size='l'>
+        {children}
+      </SpacingInset>
+    </Box>
   )
 }
 
-const styles = StyleSheet.create({
-  boxStyles: {
-    borderRadius: '4px',
-    borderWidth: '1px',
-    borderStyle: 'solid',
-    borderColor: baseColors.lighterMidGrey,
-    maxWidth: '800px',
-    margin: '0 auto',
-    lineHeight: 1.5
-  }
-})
+BorderedBox.propTypes = {
+  children: PropTypes.node.isRequired
+}
 
 export default BorderedBox

--- a/src/components/shared/Icon.jsx
+++ b/src/components/shared/Icon.jsx
@@ -1,24 +1,26 @@
 import React from 'react'
-
-import { baseColors } from '../../styles/base/colors.js'
+import PropTypes from 'prop-types'
 
 /**
  * Displays a given SVG path
  * Heavily inspired by David Gilbertsons article:
  * https://medium.com/@david.gilbertson/icons-as-react-components-de3e33cb8792
  */
-function Icon(props) {
-  // If no size is given, default to 22 x 22
-  let size = props.size || '22'
+const Icon = ({ size, color, icon }) => (
+  <svg width={size} height={size} viewBox="0 0 1024 1024">
+    <path style={{fill: color}} d={icon}></path>
+  </svg>
+)
 
-  // If no color is given, default to black
-  let color = props.color || baseColors.black
+Icon.propTypes = {
+  size: PropTypes.number,
+  color: PropTypes.string,
+  icon: PropTypes.string.isRequired
+}
 
-  return (
-    <svg width={size} height={size} viewBox="0 0 1024 1024">
-      <path style={{fill: color}} d={props.icon}></path>
-    </svg>
-  )
+Icon.defaultProps = {
+  size: 22,
+  color: 'currentColor'
 }
 
 export default Icon

--- a/src/components/summary/Summary.jsx
+++ b/src/components/summary/Summary.jsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import { StyleSheet, css } from 'aphrodite'
 
-import { extractScopeInformation } from '../../helpers/functions/scopes.js'
 import {appColors} from '../../styles/base/colors.js'
 import SpacingStack from '../helpers/spacing/SpacingStack.jsx'
 import SpacingInset from '../helpers/spacing/SpacingInset.jsx'
@@ -18,11 +17,10 @@ import TableDisplay from './TableDisplay.jsx'
 class Summary extends React.Component {
 
   buildScopeSummary(scopes) {
-    let extractedScopes = extractScopeInformation(scopes)
     let summaryElemets = []
 
-    for (var i = 0; i < extractedScopes.length; i++) {
-      let currentScope = extractedScopes[i]
+    for (var i = 0; i < scopes.length; i++) {
+      let currentScope = scopes[i]
       summaryElemets.push(
         <div className={css(styles.singleScopeStyles)}>
           <SpacingInline size={'l'} >
@@ -31,7 +29,7 @@ class Summary extends React.Component {
           <SpacingInline size={'l'} >
             <Icon icon={currentScope.icon} color={appColors.secondary} size={42} />
           </SpacingInline>
-          <span>{currentScope.text}</span>
+          <span>{currentScope.name}</span>
         </div>
       )
     }

--- a/src/components/typography/GeneralControls.jsx
+++ b/src/components/typography/GeneralControls.jsx
@@ -12,7 +12,6 @@ class GeneralControls extends React.Component {
 
     this.handleChange = this.handleChange.bind(this)
     this.displayGeneralErrors = this.displayGeneralErrors.bind(this)
-    this.determineFontFamilies = this.determineFontFamilies.bind(this)
   }
 
   handleChange(key, value) {
@@ -35,13 +34,19 @@ class GeneralControls extends React.Component {
     return generalErrors
   }
 
-  determineFontFamilies() {
-    let scope = this.props.scopes[1]
-    return FONTS[scope]
+  determineFontFamilies = () => {
+    const { scopes } = this.props
+    const fonts = []
+
+    scopes.map(scope => {
+      if (FONTS[scope.value]) fonts.push(...FONTS[scope.value])
+    })
+
+    return fonts
   }
 
   render() {
-    let fontFamilies = this.determineFontFamilies()
+    const fontFamilies = this.determineFontFamilies()
     return (
       <div>
         <DropdownController

--- a/src/containers/ColorsContainer.js
+++ b/src/containers/ColorsContainer.js
@@ -48,7 +48,8 @@ const mapDispatchToProps = (dispatch) => {
 
 // Get the colors for the currently set scope
 const getColorsetForScope = (scope) => {
-  switch (scope) {
+  if (!scope) return COLORS
+  switch (scope.value) {
     case SCOPES.ANDROID:
       return MATERIAL_COLORS
     case SCOPES.IOS:

--- a/src/containers/SetupContainer.js
+++ b/src/containers/SetupContainer.js
@@ -1,5 +1,5 @@
 import { connect } from 'react-redux'
-import { setScope, setSetupToFinished, previousSetupStep, resetSetup } from '../actions'
+import { setScope, setScopes, setSetupToFinished, previousSetupStep, resetSetup } from '../actions'
 import Setup from '../components/setup/Setup.jsx'
 
 const mapStateToProps = (state, ownProps) => {
@@ -27,6 +27,9 @@ const mapDispatchToProps = (dispatch) => {
     },
     resetSetup: () => {
       dispatch(resetSetup())
+    },
+    setScopes: scopes => {
+      dispatch(setScopes(scopes))
     }
   }
 }

--- a/src/containers/SetupContainer.js
+++ b/src/containers/SetupContainer.js
@@ -1,14 +1,12 @@
 import { connect } from 'react-redux'
-import { setScope, setScopes, setSetupToFinished, previousSetupStep, resetSetup } from '../actions'
+import { setScopes, resetScopes } from '../actions'
 import Setup from '../components/setup/Setup.jsx'
 
-const mapStateToProps = (state, ownProps) => {
-  let setupState = state.setup
+const mapStateToProps = (state) => {
+  let scopes = state.setup.scopes
   return {
-    setupStep: setupState.setupStep,
-    setupFinished: setupState.setupFinished,
-    scopes: setupState.scopes,
-    ...ownProps
+    scopes: scopes,
+    scopesSelected: scopes.length > 0
   }
 }
 
@@ -16,21 +14,8 @@ const mapStateToProps = (state, ownProps) => {
 
 const mapDispatchToProps = (dispatch) => {
   return {
-    setScope: scope => {
-      dispatch(setScope(scope))
-    },
-    setSetupToFinished: () => {
-      dispatch(setSetupToFinished())
-    },
-    previousSetupStep: () => {
-      dispatch(previousSetupStep())
-    },
-    resetSetup: () => {
-      dispatch(resetSetup())
-    },
-    setScopes: scopes => {
-      dispatch(setScopes(scopes))
-    }
+    setScopes: scopes => dispatch(setScopes(scopes)),
+    resetScopes: () => dispatch(resetScopes())
   }
 }
 

--- a/src/helpers/constants/fonts.js
+++ b/src/helpers/constants/fonts.js
@@ -1,4 +1,7 @@
 export const FONTS = {
+  WEBSITE: [
+    'Verdana', 'Arial', 'Tahoma', 'TrebuchetMS'
+  ],
   DISPLAY: [
     'Verdana', 'Arial', 'Tahoma', 'TrebuchetMS'
   ],

--- a/src/helpers/constants/setupOptions.js
+++ b/src/helpers/constants/setupOptions.js
@@ -1,68 +1,55 @@
 import {ICONS} from './icons.js'
 import {SCOPES} from './scopes.js'
 
-export const setupOptions = [
-  {
+export const setupOptions = {
+  [SCOPES.NATIVE_APP]: {
     icon: ICONS.SMARTPHONE,
-    text: 'Native App',
+    name: 'Native App',
     value: SCOPES.NATIVE_APP,
-    shouldDisplayForScope: undefined,
-    initialOption: true
+    'subsequent_options': [
+      {
+        icon: ICONS.ANDROID,
+        name: 'Android',
+        value: SCOPES.ANDROID,
+        'subsequent_options': null
+      },
+      {
+        icon: ICONS.IOS,
+        name: 'iOS',
+        value: SCOPES.IOS,
+        'subsequent_options': null
+      }
+    ]
   },
-  {
+  [SCOPES.WEBSITE]: {
     icon: ICONS.WEBSITE,
-    text: 'Website',
+    name: 'Website',
     value: SCOPES.WEBSITE,
-    shouldDisplayForScope: undefined,
-    initialOption: true
+    'subsequent_options': null
   },
-  {
+  [SCOPES.TEXT_DOCUMENT]: {
     icon: ICONS.PAGE,
-    text: 'Text Document',
+    name: 'Text Document',
     value: SCOPES.TEXT_DOCUMENT,
-    shouldDisplayForScope: undefined,
-    initialOption: true
-  },
-  {
-    icon: ICONS.ANDROID,
-    text: 'Android',
-    value: SCOPES.ANDROID,
-    shouldDisplayForScope: 'NATIVE_APP'
-  },
-  {
-    icon: ICONS.IOS,
-    text: 'iOS',
-    value: SCOPES.IOS,
-    shouldDisplayForScope: 'NATIVE_APP'
-  },
-  {
-    icon: ICONS.RESPONSIVE,
-    text: 'Responsive',
-    value: SCOPES.RESPONSIVE,
-    shouldDisplayForScope: 'WEBSITE'
-  },
-  {
-    icon: ICONS.NOT_RESPONSIVE,
-    text: 'Not responsive',
-    value: SCOPES.NOT_RESPONSIVE,
-    shouldDisplayForScope: 'WEBSITE'
-  },
-  {
-    icon: ICONS.PAGE,
-    text: 'On Paper',
-    value: SCOPES.PAPER,
-    shouldDisplayForScope: 'TEXT_DOCUMENT'
-  },
-  {
-    icon: ICONS.DISPLAY,
-    text: 'On Display',
-    value: SCOPES.DISPLAY,
-    shouldDisplayForScope: 'TEXT_DOCUMENT'
-  },
-  {
-    icon: ICONS.DISPLAY_PAPER,
-    text: 'Paper & Display',
-    value: SCOPES.PAPER_DISPLAY,
-    shouldDisplayForScope: 'TEXT_DOCUMENT'
+    'subsequent_options': [
+      {
+        icon: ICONS.PAGE,
+        name: 'On Paper',
+        value: SCOPES.PAPER,
+        'subsequent_options': null
+      },
+      {
+        icon: ICONS.DISPLAY,
+        name: 'On Display',
+        value: SCOPES.DISPLAY,
+        'subsequent_options': null
+      },
+      {
+        icon: ICONS.DISPLAY_PAPER,
+        name: 'Paper & Display',
+        value: SCOPES.PAPER_DISPLAY,
+        'subsequent_options': null
+      }
+    ]
   }
-]
+}

--- a/src/index.js
+++ b/src/index.js
@@ -16,7 +16,8 @@ import SummaryContainer from './containers/SummaryContainer.js'
 
 let store = createStore(
   ApplicationState,
-  applyMiddleware(logger)
+  applyMiddleware(logger),
+  window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__()
 )
 
 ReactDOM.render(

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@ import React from 'react'
 import ReactDOM from 'react-dom'
 import { BrowserRouter as Router, Route, Switch } from 'react-router-dom'
 import { Provider } from 'react-redux'
-import { createStore, applyMiddleware } from 'redux'
+import { createStore, applyMiddleware, compose } from 'redux'
 import ApplicationState from './reducers/ApplicationState.js'
 import logger from 'redux-logger'
 
@@ -16,8 +16,10 @@ import SummaryContainer from './containers/SummaryContainer.js'
 
 let store = createStore(
   ApplicationState,
-  applyMiddleware(logger),
-  window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__()
+  compose(
+    applyMiddleware(logger),
+    window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__()
+  )
 )
 
 ReactDOM.render(

--- a/src/reducers/setup.js
+++ b/src/reducers/setup.js
@@ -1,8 +1,6 @@
-import { SET_SCOPE, SET_SCOPES, SET_SETUP_TO_FINISHED, PREVIOUS_SETUP_STEP, RESET_SETUP } from '../actions'
+import { SET_SCOPES, RESET_SCOPES } from '../actions'
 
 const initialState = {
-  setupStep: 1,
-  setupFinished: false,
   scopes: []
 }
 
@@ -10,29 +8,11 @@ const setup = (state = initialState, action) => {
   switch (action.type) {
     case SET_SCOPES:
       return Object.assign({}, state, {
-        scopes: [...action.scopes],
-        setupFinished: true
+        scopes: [...action.scopes]
       })
-    case SET_SCOPE:
+    case RESET_SCOPES:
       return Object.assign({}, state, {
-        setupStep: state.setupStep + 1,
-        scopes: [
-          ...state.scopes,
-          action.scope
-        ]
-      })
-    case SET_SETUP_TO_FINISHED:
-      return Object.assign({}, state, {
-        setupFinished: true
-      })
-    case PREVIOUS_SETUP_STEP:
-      return Object.assign({}, state, {
-        setupStep: state.setupStep - 1,
-        scopes: state.scopes.slice(0, -1)
-      })
-    case RESET_SETUP:
-      return Object.assign({}, state, {
-        ...initialState
+        scopes: []
       })
     default:
       return state

--- a/src/reducers/setup.js
+++ b/src/reducers/setup.js
@@ -1,4 +1,4 @@
-import { SET_SCOPE, SET_SETUP_TO_FINISHED, PREVIOUS_SETUP_STEP, RESET_SETUP } from '../actions'
+import { SET_SCOPE, SET_SCOPES, SET_SETUP_TO_FINISHED, PREVIOUS_SETUP_STEP, RESET_SETUP } from '../actions'
 
 const initialState = {
   setupStep: 1,
@@ -8,6 +8,11 @@ const initialState = {
 
 const setup = (state = initialState, action) => {
   switch (action.type) {
+    case SET_SCOPES:
+      return Object.assign({}, state, {
+        scopes: [...action.scopes],
+        setupFinished: true
+      })
     case SET_SCOPE:
       return Object.assign({}, state, {
         setupStep: state.setupStep + 1,

--- a/stories/index.js
+++ b/stories/index.js
@@ -39,6 +39,16 @@ storiesOf('Buttons', module)
       Smartphone
     </IconButton>
   ))
+  .add('Icon Button active', () => (
+    <IconButton
+      onClick={action('clicked')}
+      icon={ICONS.SMARTPHONE}
+      isActive
+    >
+      Smartphone
+    </IconButton>
+  ))
+
 
 storiesOf('Icons', module)
   .add('Regular Icon', () => (

--- a/stories/index.js
+++ b/stories/index.js
@@ -3,6 +3,8 @@ import { storiesOf, action } from '@storybook/react'
 import { MemoryRouter } from 'react-router'
 
 import {ICONS} from '../src/helpers/constants/icons.js'
+import {setupOptions} from '../src/helpers/constants/setupOptions.js'
+
 import { appColors } from '../src/styles/base/colors.js'
 
 import SpacingInset from '../src/components/helpers/spacing/SpacingInset.jsx'
@@ -10,6 +12,7 @@ import SpacingInset from '../src/components/helpers/spacing/SpacingInset.jsx'
 import NavigationButton from '../src/components/shared/NavigationButton.jsx'
 import SecondaryButton from '../src/components/shared/SecondaryButton.jsx'
 import IconButton from '../src/components/setup/IconButton.jsx'
+import IconButtonList from '../src/components/setup/IconButtonList.jsx'
 import Icon from '../src/components/shared/Icon.jsx'
 import TabNavigation from '../src/components/typography/TabNavigation.jsx'
 import TabTitle from '../src/components/typography/TabTitle.jsx'
@@ -47,6 +50,13 @@ storiesOf('Buttons', module)
     >
       Smartphone
     </IconButton>
+  ))
+  .add('IconButtonList', () => (
+    <IconButtonList
+      items={Object.values(setupOptions)}
+      onItemClick={() => {}}
+      activeItem={Object.values(setupOptions)[0].value}
+    />
   ))
 
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,59 @@
 # yarn lockfile v1
 
 
+"@babel/code-frame@7.0.0-beta.31":
+  version "7.0.0-beta.31"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.0.0-beta.31.tgz#473d021ecc573a2cce1c07d5b509d5215f46ba35"
+  dependencies:
+    chalk "^2.0.0"
+    esutils "^2.0.2"
+    js-tokens "^3.0.0"
+
+"@babel/helper-function-name@7.0.0-beta.31":
+  version "7.0.0-beta.31"
+  resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.31.tgz#afe63ad799209989348b1109b44feb66aa245f57"
+  dependencies:
+    "@babel/helper-get-function-arity" "7.0.0-beta.31"
+    "@babel/template" "7.0.0-beta.31"
+    "@babel/traverse" "7.0.0-beta.31"
+    "@babel/types" "7.0.0-beta.31"
+
+"@babel/helper-get-function-arity@7.0.0-beta.31":
+  version "7.0.0-beta.31"
+  resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.31.tgz#1176d79252741218e0aec872ada07efb2b37a493"
+  dependencies:
+    "@babel/types" "7.0.0-beta.31"
+
+"@babel/template@7.0.0-beta.31":
+  version "7.0.0-beta.31"
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.0.0-beta.31.tgz#577bb29389f6c497c3e7d014617e7d6713f68bda"
+  dependencies:
+    "@babel/code-frame" "7.0.0-beta.31"
+    "@babel/types" "7.0.0-beta.31"
+    babylon "7.0.0-beta.31"
+    lodash "^4.2.0"
+
+"@babel/traverse@7.0.0-beta.31":
+  version "7.0.0-beta.31"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.0.0-beta.31.tgz#db399499ad74aefda014f0c10321ab255134b1df"
+  dependencies:
+    "@babel/code-frame" "7.0.0-beta.31"
+    "@babel/helper-function-name" "7.0.0-beta.31"
+    "@babel/types" "7.0.0-beta.31"
+    babylon "7.0.0-beta.31"
+    debug "^3.0.1"
+    globals "^10.0.0"
+    invariant "^2.2.0"
+    lodash "^4.2.0"
+
+"@babel/types@7.0.0-beta.31":
+  version "7.0.0-beta.31"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.0.0-beta.31.tgz#42c9c86784f674c173fb21882ca9643334029de4"
+  dependencies:
+    esutils "^2.0.2"
+    lodash "^4.2.0"
+    to-fast-properties "^2.0.0"
+
 "@hypnosphi/fuse.js@^3.0.9":
   version "3.0.9"
   resolved "https://registry.yarnpkg.com/@hypnosphi/fuse.js/-/fuse.js-3.0.9.tgz#ea99f6121b4a8f065b4c71f85595db2714498807"
@@ -516,6 +569,15 @@ babel-core@^6.24.1, babel-core@^6.26.0:
     private "^0.1.7"
     slash "^1.0.0"
     source-map "^0.5.6"
+
+babel-eslint@^8.0.3:
+  version "8.0.3"
+  resolved "https://registry.yarnpkg.com/babel-eslint/-/babel-eslint-8.0.3.tgz#f29ecf02336be438195325cd47c468da81ee4e98"
+  dependencies:
+    "@babel/code-frame" "7.0.0-beta.31"
+    "@babel/traverse" "7.0.0-beta.31"
+    "@babel/types" "7.0.0-beta.31"
+    babylon "7.0.0-beta.31"
 
 babel-generator@^6.26.0:
   version "6.26.0"
@@ -1408,6 +1470,10 @@ babel-types@^6.19.0, babel-types@^6.24.1, babel-types@^6.26.0:
     esutils "^2.0.2"
     lodash "^4.17.4"
     to-fast-properties "^1.0.3"
+
+babylon@7.0.0-beta.31:
+  version "7.0.0-beta.31"
+  resolved "https://registry.yarnpkg.com/babylon/-/babylon-7.0.0-beta.31.tgz#7ec10f81e0e456fd0f855ad60fa30c2ac454283f"
 
 babylon@^6.18.0:
   version "6.18.0"
@@ -3072,6 +3138,10 @@ global@^4.3.2:
     min-document "^2.19.0"
     process "~0.5.1"
 
+globals@^10.0.0:
+  version "10.4.0"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-10.4.0.tgz#5c477388b128a9e4c5c5d01c7a2aca68c68b2da7"
+
 globals@^11.0.1:
   version "11.1.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-11.1.0.tgz#632644457f5f0e3ae711807183700ebf2e4633e4"
@@ -3470,7 +3540,7 @@ interpret@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.1.0.tgz#7ed1b1410c6a0e0f78cf95d3b8440c63f78b8614"
 
-invariant@^2.0.0, invariant@^2.2.1, invariant@^2.2.2:
+invariant@^2.0.0, invariant@^2.2.0, invariant@^2.2.1, invariant@^2.2.2:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.2.tgz#9e1f56ac0acdb6bf303306f338be3b204ae60360"
   dependencies:
@@ -6058,6 +6128,10 @@ to-arraybuffer@^1.0.0:
 to-fast-properties@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-1.0.3.tgz#b83571fa4d8c25b82e231b06e3a3055de4ca1a47"
+
+to-fast-properties@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-2.0.0.tgz#dc5e698cbd079265bc73e0377681a4e4e83f616e"
 
 toposort@^1.0.0:
   version "1.0.6"


### PR DESCRIPTION
Closes #18  

Basically removes the options for a responsive website from the selectable scopes, since it has no further value.
On the way, a lot of rewrites were done, affecting mostly the setup.

* Smaller components in the setup progress
* Data representation of scopes was changed
  * Due to this, all parts of the app had to be adapted to the new representation
  * typography and colors are rather hotfixed, but I have the strong feeling these will be touched again anyways
* Added glamorous and started removing aphrodite for styling
* Added some configs to be allowed to use arrow functions inside classes.
