### PR TITLE
v2.0.3

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,9 +2,8 @@ import React from 'react'
 import ReactDOM from 'react-dom'
 import { BrowserRouter as Router, Route, Switch } from 'react-router-dom'
 import { Provider } from 'react-redux'
-import { createStore, applyMiddleware, compose } from 'redux'
+import { createStore } from 'redux'
 import ApplicationState from './reducers/ApplicationState.js'
-import logger from 'redux-logger'
 
 import './styles/global.css'
 import './styles/normalize.css'
@@ -16,10 +15,7 @@ import SummaryContainer from './containers/SummaryContainer.js'
 
 let store = createStore(
   ApplicationState,
-  compose(
-    applyMiddleware(logger),
-    window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__()
-  )
+  window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__()
 )
 
 ReactDOM.render(


### PR DESCRIPTION
prepare release v2.0.3

Hotfix: Remove redux logger. Having both, redux logger and redux dev tool inside the compose function would lead to the app crashing on browsers that do not have the redux dev tools extension installed