### PR TITLE
Redirect to root if no scopes present

### DIFF
--- a/src/components/colors/Colors.jsx
+++ b/src/components/colors/Colors.jsx
@@ -7,6 +7,7 @@ import SpacingStack from '../helpers/spacing/SpacingStack.jsx'
 import ColorSummary from './ColorSummary.jsx'
 import Progress from '../shared/Progress.jsx'
 import BottomNavigation from '../shared/BottomNavigation.jsx'
+import EnsureScopesPresent from '../../utils/EnsureScopesPresent.jsx'
 
 import {MATERIAL_COLOR_SHADES} from '../../helpers/constants/colors.js'
 import {SCOPES} from '../../helpers/constants/scopes.js'
@@ -158,4 +159,4 @@ class Colors extends React.Component {
   }
 }
 
-export default Colors
+export default EnsureScopesPresent(Colors)

--- a/src/components/setup/Setup.jsx
+++ b/src/components/setup/Setup.jsx
@@ -10,7 +10,7 @@ import BottomNavigation from '../shared/BottomNavigation.jsx'
 
 import {setupOptions} from '../../helpers/constants/setupOptions.js'
 
-export default class App extends React.Component {
+class App extends React.Component {
   constructor(props) {
     super(props)
 
@@ -49,3 +49,5 @@ export default class App extends React.Component {
     )
   }
 }
+
+export default App

--- a/src/components/summary/Summary.jsx
+++ b/src/components/summary/Summary.jsx
@@ -13,6 +13,7 @@ import BorderedBox from '../shared/BorderedBox.jsx'
 import SecondaryButton from '../shared/SecondaryButton.jsx'
 import { generatePDF } from '../../helpers/functions/pdfGenerator.js'
 import TableDisplay from './TableDisplay.jsx'
+import EnsureScopesPresent from '../../utils/EnsureScopesPresent.jsx'
 
 class Summary extends React.Component {
 
@@ -230,4 +231,4 @@ const styles = StyleSheet.create({
   }
 })
 
-export default Summary
+export default EnsureScopesPresent(Summary)

--- a/src/components/typography/Typography.jsx
+++ b/src/components/typography/Typography.jsx
@@ -17,10 +17,11 @@ import TextWidthCalculator from './TextWidthCalculator.jsx'
 import Progress from '../shared/Progress.jsx'
 import BottomNavigation from '../shared/BottomNavigation.jsx'
 import SecondaryButton from '../shared/SecondaryButton.jsx'
+import EnsureScopesPresent from '../../utils/EnsureScopesPresent.jsx'
 
 import calculateApplicationErrors from '../../helpers/errors'
 
-export default class Typography extends React.Component {
+class Typography extends React.Component {
   constructor(props) {
     super(props)
 
@@ -219,3 +220,5 @@ export default class Typography extends React.Component {
     )
   }
 }
+
+export default EnsureScopesPresent(Typography)

--- a/src/containers/ColorsContainer.js
+++ b/src/containers/ColorsContainer.js
@@ -11,6 +11,7 @@ const mapStateToProps = (state, ownProps) => {
   let colorSet = getColorsetForScope(scopes[1])
 
   return {
+    scopesPresent: state.setup.scopes.length > 0,
     ...colorState,
     colorSet,
     scopes: [

--- a/src/containers/SetupContainer.js
+++ b/src/containers/SetupContainer.js
@@ -5,6 +5,7 @@ import Setup from '../components/setup/Setup.jsx'
 const mapStateToProps = (state) => {
   let scopes = state.setup.scopes
   return {
+    scopesPresent: state.setup.scopes.length > 0,
     scopes: scopes,
     scopesSelected: scopes.length > 0
   }

--- a/src/containers/SummaryContainer.js
+++ b/src/containers/SummaryContainer.js
@@ -4,6 +4,7 @@ import Summary from '../components/summary/Summary.jsx'
 const mapStateToProps = (state, ownProps) => {
 
   return {
+    scopesPresent: state.setup.scopes.length > 0,
     ...state,
     ...ownProps
   }

--- a/src/containers/TypographyContainer.js
+++ b/src/containers/TypographyContainer.js
@@ -8,6 +8,7 @@ const mapStateToProps = (state, ownProps) => {
 
   return {
     ...typographyState,
+    scopesPresent: state.setup.scopes.length > 0,
     scopes: [
       ...scopes
     ],

--- a/src/utils/EnsureScopesPresent.jsx
+++ b/src/utils/EnsureScopesPresent.jsx
@@ -1,0 +1,18 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { Redirect } from 'react-router'
+
+
+const EnsureScopesPresent = (WrappedComponent) => {
+  const EnsureScopesPresent = (props) => {
+    if (props.scopesPresent) return <WrappedComponent {...props} />
+    return <Redirect to="/" />
+  }
+
+  EnsureScopesPresent.propTypes = {
+    scopesPresent: PropTypes.bool.isRequired
+  }
+  return EnsureScopesPresent
+}
+
+export default EnsureScopesPresent


### PR DESCRIPTION
Fixes #26 

Adds a higher order component (`EnsureScopesPresent`) that is implemented by all root component except the setup. The HoC checks if scopes are present in the store. If not, it redirects to the root path.

All containers have been adapted to provide a prop that gives information about the presence of scopes in the store.
